### PR TITLE
Feature/improved pixel update performance

### DIFF
--- a/PixelProject/AcidPixel.h
+++ b/PixelProject/AcidPixel.h
@@ -25,7 +25,25 @@ public:
    }
 
 protected:
-   int8_t NorthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      switch (direction)
+      {
+      case E_ChunkDirection::North:
+         return NorthLogic(neighbour, pixel_results);
+      case E_ChunkDirection::East:
+      case E_ChunkDirection::West:
+      case E_ChunkDirection::SouthEast:
+      case E_ChunkDirection::South:
+      case E_ChunkDirection::SouthWest:
+         return Logic(neighbour, pixel_results);
+      default:
+         return E_LogicResults::FailedUpdate;
+      }
+   }
+
+private:
+   inline int8_t NorthLogic(const E_PixelType type, E_PixelType return_pixels[2])
    {
       if (type == E_PixelType::Water)
       {
@@ -34,12 +52,7 @@ protected:
       }
       return E_LogicResults::FailedUpdate;
    }
-   int8_t WestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
-   int8_t EastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
-   int8_t SouthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
-   int8_t SouthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
-   int8_t SouthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
-private:
+
    inline int8_t Logic(const E_PixelType type, E_PixelType return_pixels[2])
    {
       switch (type)

--- a/PixelProject/AcidPixel.h
+++ b/PixelProject/AcidPixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class AcidPixel : public BasePixel
+class AcidPixel final : public BasePixel
 {
 public:
 

--- a/PixelProject/BasePixel.h
+++ b/PixelProject/BasePixel.h
@@ -49,7 +49,7 @@ public:
    short pixel_index = -1;
    short colour_count = 0;
 
-   Uint32 GetRandomColour() { return type_colours[(colour_count <= 1 ? 0 : rng() % (colour_count))]; }
+   Uint32 GetRandomColour() const { return type_colours[(colour_count <= 1 ? 0 : rng() % (colour_count))]; }
    Uint32 type_colours[Constant::pixel_max_colour_count] = {0};
 
    float render_colours[Constant::pixel_max_colour_count][4] = { 0.0f };
@@ -82,7 +82,7 @@ protected:
       }
    };
 
-   void InsertPixelUpdateOrder(const int index, std::vector<short> directions)
+   void InsertPixelUpdateOrder(const int index, const std::vector<short> directions)
    {
       if (index < Constant::pixel_max_pixel_update_order)
       {

--- a/PixelProject/BasePixel.h
+++ b/PixelProject/BasePixel.h
@@ -6,6 +6,7 @@
 #include "XoshiroCpp.hpp"
 #include <random>
 #include "PixelDataMasks.h"
+#include "PixelUpdateResult.h"
 
 #include "ColourUtility.h"
 
@@ -59,7 +60,8 @@ public:
 
 
    // Pixel Logic, this replaces all the quardrant logic into one virtual call
-   virtual int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) = 0;
+   // virtual int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) = 0;
+   virtual void UpdatePixel(PixelUpdateResult& data) = 0;
 
    // The Pixel updates itself without moving, pixels that use lifetimes may change their internal values.
    virtual bool PixelLifeTimeUpdate(Uint32& pixelValue, uint8_t rnd_value) { return true;}

--- a/PixelProject/BasePixel.h
+++ b/PixelProject/BasePixel.h
@@ -57,22 +57,9 @@ public:
    uint8_t MaxUpdateRange = 1;
    //x virtual inline int8_t MaxUpdateRange() { return 1; }
 
-   // Calls the derived North (UP) Pixel logic, returning a E_LogicResults value.
-   virtual int8_t NorthLogic(const E_PixelType type, E_PixelType return_pixels[2]) { return false; }
-   // Calls the derived North-East (UP RIGHT) Pixel logic, returning a E_LogicResults value.
-   virtual int8_t NorthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) { return false; }
-   // Calls the derived East (RIGHT) Pixel logic, returning a E_LogicResults value.
-   virtual int8_t EastLogic(const E_PixelType type, E_PixelType return_pixels[2]) { return false; }
-   // Calls the derived South-East (DOWN RIGHT) Pixel logic, returning a E_LogicResults value.
-   virtual int8_t SouthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) { return false; }
-   // Calls the derived South (DOWN) Pixel logic, returning a E_LogicResults value.
-   virtual int8_t SouthLogic(const E_PixelType type, E_PixelType return_pixels[2]) { return false; }
-   // Calls the derived South-West (DOWN RIGHT) Pixel logic, returning a E_LogicResults value.
-   virtual int8_t SouthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) { return false; }
-   // Calls the derived West (RIGHT) Pixel logic, returning a E_LogicResults value.
-   virtual int8_t WestLogic(const E_PixelType type, E_PixelType return_pixels[2]) { return false; }
-   // Calls the derived North-West (UP RIGHT) Pixel logic, returning a E_LogicResults value.
-   virtual int8_t NorthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) { return false; }
+
+   // Pixel Logic, this replaces all the quardrant logic into one virtual call
+   virtual int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) = 0;
 
    // The Pixel updates itself without moving, pixels that use lifetimes may change their internal values.
    virtual bool PixelLifeTimeUpdate(Uint32& pixelValue, uint8_t rnd_value) { return true;}

--- a/PixelProject/Constants.h
+++ b/PixelProject/Constants.h
@@ -87,7 +87,7 @@ namespace PixelProject::Constant
 }
 
 // Can be used to Identify the Index of a Pixel
-enum class E_PixelType
+enum class E_PixelType : int8_t
 {
    UNDEFINED = -1,
    Space,

--- a/PixelProject/FirePixel.h
+++ b/PixelProject/FirePixel.h
@@ -38,7 +38,8 @@ public:
       return lightLevel | pixel_index | lifeTime;
    }
 
-   bool PixelLifeTimeUpdate(Uint32& pixel, const uint8_t rng_value) override {
+   bool PixelLifeTimeUpdate(Uint32& pixel, const uint8_t rng_value) override
+   {
       //TODO Maybe Make a subtract 1 method for lifetime so we don't have to do this every frame
 
       // 1 in 5 chance to reduce lifetime.

--- a/PixelProject/FirePixel.h
+++ b/PixelProject/FirePixel.h
@@ -26,30 +26,6 @@ public:
          { North, NorthWest, NorthEast, SouthWest, SouthEast, South });
    }
 
-   int8_t NorthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override
-   {
-      return Logic(type, return_pixels);
-   }
-
-   int8_t NorthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override
-   {
-      return Logic(type, return_pixels);
-   }
-
-   int8_t NorthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
-
-   int8_t SouthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override
-   {
-      return Logic(type, return_pixels);
-   }
-
-   int8_t SouthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override
-   {
-      return Logic(type, return_pixels);
-   }
-
-   int8_t SouthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
-
    Uint32 GetNewPixel() override
    {
       // We always want it to glow
@@ -75,6 +51,23 @@ public:
       PBit::SetLifetime(pixel, lifetime);
 
       return lifetime > 0;
+   }
+
+protected:
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      switch (direction)
+      {
+      case E_ChunkDirection::North:
+      case E_ChunkDirection::NorthEast:
+      case E_ChunkDirection::NorthWest:
+      case E_ChunkDirection::SouthEast:
+      case E_ChunkDirection::South:
+      case E_ChunkDirection::SouthWest:
+         return Logic(neighbour, pixel_results);
+      default:
+         return E_LogicResults::FailedUpdate;
+      }
    }
 
 private:
@@ -114,6 +107,4 @@ private:
       return_pixels[0] = E_PixelType::Space;
       return E_LogicResults::FirstReturnPixel;
    }
-
-private:
 };

--- a/PixelProject/FirePixel.h
+++ b/PixelProject/FirePixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class FirePixel : public BasePixel
+class FirePixel final : public BasePixel
 {
 public:
    short minLifetime = 5;

--- a/PixelProject/FirePixel.h
+++ b/PixelProject/FirePixel.h
@@ -55,9 +55,9 @@ public:
    }
 
 protected:
-   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      switch (direction)
+      switch (data.Dir())
       {
       case E_ChunkDirection::North:
       case E_ChunkDirection::NorthEast:
@@ -65,47 +65,48 @@ protected:
       case E_ChunkDirection::SouthEast:
       case E_ChunkDirection::South:
       case E_ChunkDirection::SouthWest:
-         return Logic(neighbour, pixel_results);
+         Logic(data);
+         return;
       default:
-         return E_LogicResults::FailedUpdate;
+         data.Fail();
       }
    }
 
 private:
-   inline int8_t Logic(const E_PixelType type, E_PixelType return_pixels[2])
+   void Logic(PixelUpdateResult& data)
    {
-      switch (type)
+      switch (data.NeighbourType())
       {
       case E_PixelType::Space:
-         return rng() % 2 == 0 ? E_LogicResults::SuccessUpdate : E_LogicResults::FailedUpdate;
+         rng() % 2 == 0 ? data.Pass() : data.Fail();
+         return;
 
 
       case E_PixelType::Oil:
-         return_pixels[0] = E_PixelType::Fire;
-         return_pixels[1] = E_PixelType::Fire;
-         return E_LogicResults::DualReturnPixel;
+         data.SetLocalAndNeighbour(E_PixelType::Fire, E_PixelType::Fire);
+         return;
 
 
       case E_PixelType::Wood:
          if (rng() % 10 == 0)
          {
-            return_pixels[0] = E_PixelType::Fire;
-            return_pixels[1] = E_PixelType::Fire;
-            return E_LogicResults::DualReturnPixel;
+            data.SetLocalAndNeighbour(E_PixelType::Fire, E_PixelType::Fire);
+            return;
          }
-         return E_LogicResults::FailedUpdate;
+         data.Fail();
+         return;
 
 
       case E_PixelType::Fire:
-         return E_LogicResults::FailedUpdate;
+         data.Fail();
+         return;
 
       case E_PixelType::Water:
-         return_pixels[0] = E_PixelType::Steam;
-         return_pixels[1] = E_PixelType::Space;
-         return E_LogicResults::DualReturnPixel;
+         data.SetLocalAndNeighbour(E_PixelType::Steam, E_PixelType::Space);
+         return;
       }
 
-      return_pixels[0] = E_PixelType::Space;
-      return E_LogicResults::FirstReturnPixel;
+      data.SetLocal(E_PixelType::Space);
+      return;
    }
 };

--- a/PixelProject/GoldPixel.h
+++ b/PixelProject/GoldPixel.h
@@ -24,9 +24,18 @@ public:
    }
 
 protected:
-   int8_t SouthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t SouthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t SouthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      switch (direction)
+      {
+      case E_ChunkDirection::SouthEast:
+      case E_ChunkDirection::South:
+      case E_ChunkDirection::SouthWest:
+         return Logic(neighbour);
+      default:
+         return false;
+      }
+   }
 
 private:
    inline int8_t Logic(const E_PixelType type)

--- a/PixelProject/GoldPixel.h
+++ b/PixelProject/GoldPixel.h
@@ -24,32 +24,38 @@ public:
    }
 
 protected:
-   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      switch (direction)
+      switch (data.Dir())
       {
       case E_ChunkDirection::SouthEast:
       case E_ChunkDirection::South:
       case E_ChunkDirection::SouthWest:
-         return Logic(neighbour);
+         Logic(data);
+         return;
       default:
-         return false;
+         data.Fail();
       }
    }
 
 private:
-   inline int8_t Logic(const E_PixelType type)
+   void Logic(PixelUpdateResult& data)
    {
-      switch (type)
+      switch (data.NeighbourType())
       {
       case E_PixelType::Space:
       case E_PixelType::Water:
-         return E_LogicResults::SuccessUpdate;
+         data.Pass();
+         return;
       case E_PixelType::Oil:
-         return (rng() % 3 == 0 ? E_LogicResults::SuccessUpdate : E_LogicResults::FailedUpdate);
+         rng() % 3 == 0 ? data.Pass() : data.Fail();
+         return;
       case E_PixelType::Sand:
-         return (rng() % 6 == 0 ? E_LogicResults::SuccessUpdate : E_LogicResults::FailedUpdate);
+         rng() % 6 == 0 ? data.Pass() : data.Fail();
+         return;
+      default:
+         data.Fail();
+         return;
       }
-      return E_LogicResults::FailedUpdate;
    }
 };

--- a/PixelProject/GoldPixel.h
+++ b/PixelProject/GoldPixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class GoldPixel : public BasePixel
+class GoldPixel final : public BasePixel
 {
 public:
 

--- a/PixelProject/GroundPixel.h
+++ b/PixelProject/GroundPixel.h
@@ -30,9 +30,9 @@ public:
    }
 
 protected:
-   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      return E_LogicResults::FailedUpdate;
+      data.Fail();
    }
 
 private:

--- a/PixelProject/GroundPixel.h
+++ b/PixelProject/GroundPixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class GroundPixel : public BasePixel
+class GroundPixel final : public BasePixel
 {
 public:
 

--- a/PixelProject/GroundPixel.h
+++ b/PixelProject/GroundPixel.h
@@ -28,5 +28,12 @@ public:
 
       return lightLevel | pixel_index;
    }
+
+protected:
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      return E_LogicResults::FailedUpdate;
+   }
+
 private:
 };

--- a/PixelProject/OilPixel.h
+++ b/PixelProject/OilPixel.h
@@ -33,15 +33,26 @@ public:
                              });
    }
 
-   int8_t NorthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return NorthLogic(type, 4); }
-   int8_t NorthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return NorthLogic(type, 4); }
-   int8_t NorthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return NorthLogic(type); }
-
-   int8_t SouthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t SouthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t SouthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t WestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t EastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
+protected:
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      switch (direction)
+      {
+      case E_ChunkDirection::North:
+         return NorthLogic(neighbour);
+      case E_ChunkDirection::NorthEast:
+      case E_ChunkDirection::NorthWest:
+         return NorthLogic(neighbour, 4);
+      case E_ChunkDirection::SouthEast:
+      case E_ChunkDirection::South:
+      case E_ChunkDirection::SouthWest:
+      case E_ChunkDirection::West:
+      case E_ChunkDirection::East:
+         return Logic(neighbour);
+      default:
+         return E_LogicResults::FailedUpdate;
+      }
+   }
 
 private:
    inline int8_t NorthLogic(const E_PixelType type, const int odds = 2)
@@ -63,6 +74,4 @@ private:
       }
       return E_LogicResults::FailedUpdate;
    }
-
-private:
 };

--- a/PixelProject/OilPixel.h
+++ b/PixelProject/OilPixel.h
@@ -1,6 +1,4 @@
 ﻿#pragma once
-
-#pragma once
 #include "BasePixel.h"
 
 class OilPixel final : public BasePixel
@@ -34,44 +32,48 @@ public:
    }
 
 protected:
-   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      switch (direction)
+      switch (data.Dir())
       {
-      case E_ChunkDirection::North:
-         return NorthLogic(neighbour);
-      case E_ChunkDirection::NorthEast:
-      case E_ChunkDirection::NorthWest:
-         return NorthLogic(neighbour, 4);
-      case E_ChunkDirection::SouthEast:
-      case E_ChunkDirection::South:
-      case E_ChunkDirection::SouthWest:
-      case E_ChunkDirection::West:
-      case E_ChunkDirection::East:
-         return Logic(neighbour);
-      default:
-         return E_LogicResults::FailedUpdate;
+         case E_ChunkDirection::North:
+            NorthLogic(data, 2);
+            return;
+         case E_ChunkDirection::NorthEast:
+         case E_ChunkDirection::NorthWest:
+            NorthLogic(data, 4);
+            return;
+         case E_ChunkDirection::SouthEast:
+         case E_ChunkDirection::South:
+         case E_ChunkDirection::SouthWest:
+         case E_ChunkDirection::West:
+         case E_ChunkDirection::East:
+            Logic(data);
+            return;
       }
+      data.Fail();
    }
 
 private:
-   inline int8_t NorthLogic(const E_PixelType type, const int odds = 2)
+   void NorthLogic(PixelUpdateResult& data, int odds )
    {
-      switch (type)
+      switch (data.NeighbourType())
       {
       case E_PixelType::Water:
-         return rng() % odds == 0 ? E_LogicResults::SuccessUpdate : E_LogicResults::FailedUpdate;
+         rng() % odds == 0 ? data.Pass() : data.Fail();
+         return;
       }
-      return E_LogicResults::FailedUpdate;
+      data.Fail();
    }
 
-   inline int8_t Logic(const E_PixelType type)
+   void Logic(PixelUpdateResult& data)
    {
-      switch (type)
+      switch (data.NeighbourType())
       {
       case E_PixelType::Space:
-         return E_LogicResults::SuccessUpdate;
+         data.Pass();
+         return;
       }
-      return E_LogicResults::FailedUpdate;
+      data.Fail();
    }
 };

--- a/PixelProject/PixelProject.vcxproj
+++ b/PixelProject/PixelProject.vcxproj
@@ -337,6 +337,7 @@ XCOPY "$(SolutionDir)$(ProjectName)\textures" "$(TargetDir)textures\" /S/E /Y</C
     <ClInclude Include="Game.h" />
     <ClInclude Include="PixelDataMasks.h" />
     <ClInclude Include="PixelTypeIncludes.h" />
+    <ClInclude Include="PixelUpdateResult.h" />
     <ClInclude Include="RectTransform.h" />
     <ClInclude Include="RenderObject.h" />
     <ClInclude Include="RenderTarget.h" />

--- a/PixelProject/PixelProject.vcxproj.filters
+++ b/PixelProject/PixelProject.vcxproj.filters
@@ -410,6 +410,9 @@
     <ClInclude Include="RenderObject.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="PixelUpdateResult.h">
+      <Filter>Header Files\World\Utility</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/PixelProject/PixelUpdateResult.h
+++ b/PixelProject/PixelUpdateResult.h
@@ -1,0 +1,57 @@
+#pragma once
+
+/**
+ * Container Type\n
+ * [0] = E_LogicResults\n
+ * [1] = NeighbourType\n
+ * [2] = NewPixel = E_PixelType (Local)\n
+ * [3] = NewPixel = E_PixelType (Neighbour)\n
+ * [4] = E_ChunkDirection (Pixel Update Direction)
+ */
+class PixelUpdateResult
+{
+private:
+   int8_t results[5];
+public:
+
+   // Result
+   inline E_LogicResults Result() { return static_cast<E_LogicResults>(results[0]); }
+   inline void SetResult(const E_LogicResults result) { results[0] = result; }
+
+   // Neighbour
+   inline E_PixelType NeighbourType() { return static_cast<E_PixelType>(results[1]); }
+   inline void SetNeighbour(const E_PixelType type) { results[1] = static_cast<int8_t>(type); }
+
+   // Local NewPixel
+   inline E_PixelType NewLocal() { return static_cast<E_PixelType>(results[2]); }
+   inline void SetLocal(const E_PixelType type)
+   {
+      results[2] = static_cast<int8_t>(type);
+      results[0] = static_cast<int8_t>(E_LogicResults::FirstReturnPixel);
+   }
+
+   // Neighbour NewPixel
+   inline E_PixelType NewNeighbour() { return static_cast<E_PixelType>(results[3]); }
+   inline void SetNewNeighbour(const E_PixelType type)
+   {
+      results[3] = static_cast<int8_t>(type);
+      results[0] = static_cast<int8_t>(E_LogicResults::SecondReturnPixel);
+   }
+
+   // Direction
+   inline E_ChunkDirection Dir() { return static_cast<E_ChunkDirection>(results[4]); }
+   inline void SetDirection(const E_ChunkDirection dir) { results[4] = static_cast<int8_t>(dir); }
+
+
+   // Set Local & Neighbour Type
+   inline void SetLocalAndNeighbour(const E_PixelType local, const E_PixelType neighbour)
+   {
+      results[2] = static_cast<int8_t>(local);
+      results[3] = static_cast<int8_t>(neighbour);
+      results[0] = static_cast<int8_t>(E_LogicResults::DualReturnPixel);
+   }
+
+   // Simple one liner
+   inline void Fail() { results[0] = static_cast<int8_t>(E_LogicResults::FailedUpdate); }
+   inline void Pass() { results[0] = static_cast<int8_t>(E_LogicResults::SuccessUpdate); }
+};

--- a/PixelProject/PixelUpdateResult.h
+++ b/PixelProject/PixelUpdateResult.h
@@ -1,12 +1,16 @@
 #pragma once
 
 /**
- * Container Type\n
- * [0] = E_LogicResults\n
- * [1] = NeighbourType\n
- * [2] = NewPixel = E_PixelType (Local)\n
- * [3] = NewPixel = E_PixelType (Neighbour)\n
- * [4] = E_ChunkDirection (Pixel Update Direction)
+ Container Type\n
+ [0] = E_LogicResults\n
+ [1] = NeighbourType\n
+ [2] = NewPixel = E_PixelType (Local)\n
+ [3] = NewPixel = E_PixelType (Neighbour)\n
+ [4] = E_ChunkDirection (Pixel Update Direction)
+ 
+ Mess of a container class that is updates during pixel updates. This was made to pass only 1 reference around instead of 3 value types and 1 reference.
+ This proves to be faster, if only because most updates only require setting the first value of the container (Fail/Pass) before continuing.
+ Readability however, gets thrown out the window.
  */
 class PixelUpdateResult
 {

--- a/PixelProject/SandPixel.h
+++ b/PixelProject/SandPixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class SandPixel : public BasePixel
+class SandPixel final : public BasePixel
 {
 public:
 

--- a/PixelProject/SandPixel.h
+++ b/PixelProject/SandPixel.h
@@ -25,31 +25,35 @@ public:
    }
 
 protected:
-   inline int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      switch (direction)
+      switch (data.Dir())
       {
       case E_ChunkDirection::SouthEast:
       case E_ChunkDirection::South:
       case E_ChunkDirection::SouthWest:
-         return Logic(neighbour);
+         Logic(data);
+         return;
       default:
-         return E_LogicResults::FailedUpdate;
+         data.Fail();
       }
    }
 
 private:
-   inline int8_t Logic(const E_PixelType type)
+   void Logic(PixelUpdateResult& data)
    {
-      switch (type)
+      switch (data.NeighbourType())
       {
       case E_PixelType::Space:
-         return E_LogicResults::SuccessUpdate;
+         data.Pass();
+         return;
       case E_PixelType::Water:
-         return (rng() % 3 == 0 ? E_LogicResults::SuccessUpdate : E_LogicResults::FailedUpdate);
+         (rng() % 3 == 0 ? data.Pass() : data.Fail());
+         return;
       case E_PixelType::Oil:
-         return (rng() % 10 == 0 ? E_LogicResults::SuccessUpdate : E_LogicResults::FailedUpdate);
+         (rng() % 10 == 0 ? data.Pass() : data.Fail());
+         return;
       }
-      return E_LogicResults::FailedUpdate;
+      data.Fail();
    }
 };

--- a/PixelProject/SandPixel.h
+++ b/PixelProject/SandPixel.h
@@ -25,11 +25,21 @@ public:
    }
 
 protected:
-   int8_t SouthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t SouthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t SouthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
+   inline int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      switch (direction)
+      {
+      case E_ChunkDirection::SouthEast:
+      case E_ChunkDirection::South:
+      case E_ChunkDirection::SouthWest:
+         return Logic(neighbour);
+      default:
+         return E_LogicResults::FailedUpdate;
+      }
+   }
+
 private:
-   int8_t Logic(const E_PixelType type)
+   inline int8_t Logic(const E_PixelType type)
    {
       switch (type)
       {

--- a/PixelProject/SpacePixel.h
+++ b/PixelProject/SpacePixel.h
@@ -24,5 +24,11 @@ public:
       return pixel_index;
    }
 
+protected:
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      return E_LogicResults::FailedUpdate;
+   }
+
 private:
 };

--- a/PixelProject/SpacePixel.h
+++ b/PixelProject/SpacePixel.h
@@ -25,9 +25,9 @@ public:
    }
 
 protected:
-   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      return E_LogicResults::FailedUpdate;
+      data.Fail();
    }
 
 private:

--- a/PixelProject/SpacePixel.h
+++ b/PixelProject/SpacePixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class SpacePixel : public BasePixel
+class SpacePixel final : public BasePixel
 {
 public:
 

--- a/PixelProject/SteamPixel.h
+++ b/PixelProject/SteamPixel.h
@@ -24,46 +24,49 @@ public:
    }
 
 protected:
-   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      switch (direction)
+      switch (data.Dir())
       {
       case E_ChunkDirection::North:
       case E_ChunkDirection::NorthEast:
       case E_ChunkDirection::NorthWest:
       case E_ChunkDirection::South:
-         return Logic(neighbour, pixel_results);
+         Logic(data);
+         return;
       default:
-         return E_LogicResults::FailedUpdate;
+         data.Fail();
       }
    }
 
 private:
-   inline int8_t Logic(const E_PixelType type, E_PixelType return_pixels[2])
+   void Logic(PixelUpdateResult& data)
    {
       int rngValue = rng() % 1000;
-      switch (type)
+      switch (data.NeighbourType())
       {
-         case E_PixelType::Space:
-         case E_PixelType::Steam:
-         case E_PixelType::Water:
-            if (rngValue <= 600)
-            {
-               return E_LogicResults::SuccessUpdate;
-            }
-            else if (rngValue <= 605)
-            {
-               return_pixels[0] = E_PixelType::Water;
-               return E_LogicResults::FirstReturnPixel;
-            }
-         return E_LogicResults::FailedUpdate;
-         default:
-            if (rngValue <= 50)
-            {
-               return_pixels[0] = E_PixelType::Water;
-               return E_LogicResults::FirstReturnPixel;
-            }
+      case E_PixelType::Space:
+      case E_PixelType::Steam:
+      case E_PixelType::Water:
+         if (rngValue <= 600)
+         {
+            data.Pass();
+            return;
+         }
+         else if (rngValue <= 605)
+         {
+            data.SetLocal(E_PixelType::Water);
+            return;
+         }
+         data.Fail();
+         return;
+      default:
+         if (rngValue <= 50)
+         {
+            data.SetLocal(E_PixelType::Water);
+            return;
+         }
       }
-      return E_LogicResults::FailedUpdate;
+      data.Fail();
    }
 };

--- a/PixelProject/SteamPixel.h
+++ b/PixelProject/SteamPixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class SteamPixel : public BasePixel
+class SteamPixel final : public BasePixel
 {
 public:
 

--- a/PixelProject/SteamPixel.h
+++ b/PixelProject/SteamPixel.h
@@ -23,19 +23,20 @@ public:
                              {North, NorthWest, NorthEast, South});
    }
 
-   int8_t NorthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override
+protected:
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
    {
-      return Logic(type, return_pixels);
+      switch (direction)
+      {
+      case E_ChunkDirection::North:
+      case E_ChunkDirection::NorthEast:
+      case E_ChunkDirection::NorthWest:
+      case E_ChunkDirection::South:
+         return Logic(neighbour, pixel_results);
+      default:
+         return E_LogicResults::FailedUpdate;
+      }
    }
-
-   int8_t NorthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override
-   {
-      return Logic(type, return_pixels);
-   }
-
-   int8_t NorthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
-
-   int8_t SouthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type, return_pixels); }
 
 private:
    inline int8_t Logic(const E_PixelType type, E_PixelType return_pixels[2])
@@ -65,6 +66,4 @@ private:
       }
       return E_LogicResults::FailedUpdate;
    }
-
-private:
 };

--- a/PixelProject/WaterPixel.h
+++ b/PixelProject/WaterPixel.h
@@ -35,29 +35,32 @@ public:
    //x inline int8_t MaxUpdateRange() override { return 8; }
 
 protected:
-   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      switch (direction)
+      switch (data.Dir())
       {
       case E_ChunkDirection::East:
       case E_ChunkDirection::West:
       case E_ChunkDirection::SouthEast:
       case E_ChunkDirection::South:
       case E_ChunkDirection::SouthWest:
-         return Logic(neighbour);
+         Logic(data);
+         return;
       default:
-         return E_LogicResults::FailedUpdate;
+         data.Fail();
       }
    }
 
 private:
-   inline int8_t Logic(const E_PixelType type)
+   void Logic(PixelUpdateResult& data)
    {
-      switch (type)
+      switch (data.NeighbourType())
       {
       case E_PixelType::Space:
-         return E_LogicResults::SuccessUpdate;
+         data.Pass();
+         return;
       }
-      return E_LogicResults::FailedUpdate;
+      data.Fail();
+      return;
    }
 };

--- a/PixelProject/WaterPixel.h
+++ b/PixelProject/WaterPixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class WaterPixel : public BasePixel
+class WaterPixel final : public BasePixel
 {
 public:
 

--- a/PixelProject/WaterPixel.h
+++ b/PixelProject/WaterPixel.h
@@ -34,14 +34,24 @@ public:
 
    //x inline int8_t MaxUpdateRange() override { return 8; }
 
-   int8_t SouthEastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t SouthLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t SouthWestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t WestLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
-   int8_t EastLogic(const E_PixelType type, E_PixelType return_pixels[2]) override { return Logic(type); }
+protected:
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      switch (direction)
+      {
+      case E_ChunkDirection::East:
+      case E_ChunkDirection::West:
+      case E_ChunkDirection::SouthEast:
+      case E_ChunkDirection::South:
+      case E_ChunkDirection::SouthWest:
+         return Logic(neighbour);
+      default:
+         return E_LogicResults::FailedUpdate;
+      }
+   }
 
 private:
-   static int8_t Logic(const E_PixelType type)
+   inline int8_t Logic(const E_PixelType type)
    {
       switch (type)
       {
@@ -50,6 +60,4 @@ private:
       }
       return E_LogicResults::FailedUpdate;
    }
-
-private:
 };

--- a/PixelProject/WoodPixel.h
+++ b/PixelProject/WoodPixel.h
@@ -22,9 +22,9 @@ public:
    }
 
 protected:
-   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   void UpdatePixel(PixelUpdateResult& data) override
    {
-      return E_LogicResults::FailedUpdate;
+      data.Fail();
    }
 
 private:

--- a/PixelProject/WoodPixel.h
+++ b/PixelProject/WoodPixel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "BasePixel.h"
 
-class WoodPixel : public BasePixel
+class WoodPixel final : public BasePixel
 {
 public:
 

--- a/PixelProject/WoodPixel.h
+++ b/PixelProject/WoodPixel.h
@@ -21,5 +21,11 @@ public:
       InsertPixelUpdateOrder(0, std::vector<short>() = {});
    }
 
+protected:
+   int8_t UpdatePixel(const E_PixelType neighbour, E_PixelType pixel_results[2], int8_t direction) override
+   {
+      return E_LogicResults::FailedUpdate;
+   }
+
 private:
 };

--- a/PixelProject/WorldSimulator.cpp
+++ b/PixelProject/WorldSimulator.cpp
@@ -370,8 +370,9 @@ void WorldSimulator::FixedUpdate()
                               const auto neighbourType = pixelNeighbour->pixel_type;
 
                               // Now we ask the Pixel what it wants to do with its neighbour
-                              const int8_t result = CheckLogic(pixelDirOrder[directionIndex], pixel, neighbourType,
-                                                               returnPixels);
+                              const int8_t result = pixel->UpdatePixel(neighbourType, returnPixels, pixelDirOrder[directionIndex]);
+                                 
+                              // CheckLogic(pixelDirOrder[directionIndex], pixel, neighbourType, returnPixels);
 
                               if (DEBUG_PrintPixelData)
                               {
@@ -469,33 +470,6 @@ inline bool WorldSimulator::DoesChunkHaveNeighbour(WorldChunk** neighbours, cons
 {
    return neighbours[direction] != nullptr;
 }
-
-inline int8_t WorldSimulator::CheckLogic(const int direction, BasePixel* pixel, const E_PixelType neighbour_type,
-   E_PixelType* return_pixels)
-{
-   switch (direction)
-   {
-   case North:
-      return pixel->NorthLogic(neighbour_type, return_pixels);
-   case NorthEast:
-      return pixel->NorthEastLogic(neighbour_type, return_pixels);
-   case East:
-      return pixel->EastLogic(neighbour_type, return_pixels);
-   case SouthEast:
-      return pixel->SouthEastLogic(neighbour_type, return_pixels);
-   case South:
-      return pixel->SouthLogic(neighbour_type, return_pixels);
-   case SouthWest:
-      return pixel->SouthWestLogic(neighbour_type, return_pixels);
-   case West:
-      return pixel->WestLogic(neighbour_type, return_pixels);
-   case NorthWest:
-      return pixel->NorthWestLogic(neighbour_type, return_pixels);
-   default:
-      return E_LogicResults::FailedUpdate;
-   }
-}
-
 
 void WorldSimulator::UpdateInput()
 {

--- a/PixelProject/WorldSimulator.cpp
+++ b/PixelProject/WorldSimulator.cpp
@@ -1,5 +1,7 @@
 #include "WorldSimulator.h"
 
+#include "PixelUpdateResult.h"
+
 void WorldSimulator::Start()
 {
    // Generate our chunks and the pixel data
@@ -257,26 +259,6 @@ void WorldSimulator::FixedUpdate()
                         {
                            const short localIndex = (y * Constant::chunk_size_x) + x;
 
-                           // //? DEBUG
-                           // localPixels[localIndex] = 0x00000000;
-                           // switch (i)
-                           // {
-                           // // case 0:
-                           // //    localPixels[localIndex] += 0x40000000;
-                           // //    break;
-                           // // case 1:
-                           // //    localPixels[localIndex] += 0x00400000;
-                           // //    break;
-                           // case 2: 
-                           //   localPixels[localIndex] += 0x00004000; // These ones
-                           //   break;
-                           // case 3:
-                           //    localPixels[localIndex] += 0x40000000; // These ones
-                           //    break;
-                           // }
-                           // continue;
-                           // //? DEBUG
-
                            // If the pixel is empty space, or if the cell has already been updated we skip over it
                            if (localPixels[localIndex] == 0 || isProcessed[localIndex]) continue;
                            BasePixel* pixel = world_data_handler.GetPixelFromIndex(PBit::Index(localPixels[localIndex]));
@@ -293,7 +275,7 @@ void WorldSimulator::FixedUpdate()
                            const short* pixelDirOrder = chunk_direction_order[pixel->pixel_index];
                            for (auto directionIndex = 0; directionIndex < static_cast<short>(DIR_COUNT); directionIndex++)
                            {
-                              E_PixelType returnPixels[2];
+                              PixelUpdateResult pixelUpdateResult;
 
                               short direction = pixelDirOrder[directionIndex];
                               // If Direction is DIR_COUNT all other values will be DIR_COUNT and can be safely aborted.
@@ -367,11 +349,15 @@ void WorldSimulator::FixedUpdate()
                               }
 #endif
                               // Grab our neighbours pixel type to simplify the lookup.
-                              const auto neighbourType = pixelNeighbour->pixel_type;
+                              // const auto neighbourType = pixelNeighbour->pixel_type;
+                              pixelUpdateResult.SetNeighbour(pixelNeighbour->pixel_type);
+                              pixelUpdateResult.SetDirection(static_cast<E_ChunkDirection>(pixelDirOrder[directionIndex]));
 
                               // Now we ask the Pixel what it wants to do with its neighbour
-                              const int8_t result = pixel->UpdatePixel(neighbourType, returnPixels, pixelDirOrder[directionIndex]);
-                                 
+                              pixel->UpdatePixel(pixelUpdateResult);
+
+                              // const int8_t result = pixel->UpdatePixel(neighbourType, returnPixels, pixelDirOrder[directionIndex]);
+
                               // CheckLogic(pixelDirOrder[directionIndex], pixel, neighbourType, returnPixels);
 
                               if (DEBUG_PrintPixelData)
@@ -381,7 +367,7 @@ void WorldSimulator::FixedUpdate()
                                     neighbourIndex);
                               }
 
-                              switch (result)
+                              switch (pixelUpdateResult.Result())
                               {
                               case E_LogicResults::SuccessUpdate:
                                  std::swap(localPixels[localIndex], neighbourPixels[neighbourIndex]);
@@ -390,18 +376,18 @@ void WorldSimulator::FixedUpdate()
 
 
                               case E_LogicResults::FirstReturnPixel:
-                                 localPixels[localIndex] = world_data_handler.GetNewPixelOfType(returnPixels[0]);
+                                 localPixels[localIndex] = world_data_handler.GetNewPixelOfType(pixelUpdateResult.NewLocal());
                                  isProcessed[localIndex] = true;
                                  break;
                               case E_LogicResults::SecondReturnPixel:
-                                 neighbourPixels[neighbourIndex] = world_data_handler.GetNewPixelOfType(returnPixels[1]);
+                                 neighbourPixels[neighbourIndex] = world_data_handler.GetNewPixelOfType(pixelUpdateResult.NewNeighbour());
                                  neighbourIsProcessed[neighbourIndex] = true;
                                  break;
                               case E_LogicResults::DualReturnPixel:
-                                 localPixels[localIndex] = world_data_handler.GetNewPixelOfType(returnPixels[0]);
+                                 localPixels[localIndex] = world_data_handler.GetNewPixelOfType(pixelUpdateResult.NewLocal());
                                  isProcessed[localIndex] = true;
 
-                                 neighbourPixels[neighbourIndex] = world_data_handler.GetNewPixelOfType(returnPixels[1]);
+                                 neighbourPixels[neighbourIndex] = world_data_handler.GetNewPixelOfType(pixelUpdateResult.NewNeighbour());
                                  neighbourIsProcessed[neighbourIndex] = true;
                                  break;
                               case E_LogicResults::NoChange:

--- a/PixelProject/WorldSimulator.cpp
+++ b/PixelProject/WorldSimulator.cpp
@@ -310,8 +310,8 @@ void WorldSimulator::FixedUpdate()
                               short neighbourIndex;
                               uint32_t pixelIndexChange = 0;
 
-                              uint8_t maxPixelRange = pixel->MaxUpdateRange;
-                              uint8_t borderRange = GetDistanceToBorder(x, y, direction);
+                              //TODO uint8_t maxPixelRange = pixel->MaxUpdateRange;
+                              //TODO uint8_t borderRange = GetDistanceToBorder(x, y, direction);
 
                               switch (piece)
                               {


### PR DESCRIPTION
We use a small `int8_t [5]`container to pass around the results of a pixelupdate instead of using 3 value types and reference to `int8_t[2]`. While this does remove some readability in regards to what its purpose is, it helps performance a fair bit. 

Most pixel updates (at least at the moment) only need 1 value to represent the update pass/fail some pixels have behaviours which interact and have additional behaviour ran afterwards, but these are few and far between. Passing only 1 reference into multiple methods is far cheaper than the multiple value types.

Some methods to simplify the set/get behaviour of the container exist, these should all mostly be inlined which should further aid pixel update. Hopefully. 